### PR TITLE
Implement `col_select` for all file types

### DIFF
--- a/R/get_hscp_locality.R
+++ b/R/get_hscp_locality.R
@@ -1,27 +1,31 @@
 #' Get the HSCP Locality lookup
 #'
 #' @param version Default is "latest", otherwise supply a date e.g. "20230804"
+#' @inheritParams readr::read_csv
 #'
 #' @return a [tibble][tibble::tibble-package] of the HSCP localities lookup
 #' @export
 #'
 #' @examples
 #' get_hscp_locality()
-get_hscp_locality <- function(version = "latest") {
+get_hscp_locality <- function(version = "latest", col_select = NULL) {
   dir <- fs::path(get_lookups_dir(), "Geography", "HSCP Locality")
+
+  # If col_select is specified use CSV otherwise use RDS
+  ext <- ifelse(rlang::quo_is_null(rlang::enquo(col_select)), "rds", "csv")
 
   if (version == "latest") {
     hscp_locality_path <- find_latest_file(
       directory = dir,
-      regexp = "HSCP Localities_DZ11_Lookup_\\d{8}\\.rds",
+      regexp = paste0("HSCP Localities_DZ11_Lookup_\\d{8}\\.", ext),
       selection_method = "file_name"
     )
   } else {
     hscp_locality_path <- fs::path(
       dir,
-      glue::glue("HSCP Localities_DZ11_Lookup_{date}.rds")
+      glue::glue("HSCP Localities_DZ11_Lookup_{date}.{ext}")
     )
   }
 
-  return(read_file(hscp_locality_path))
+  return(read_file(hscp_locality_path, col_select = {{ col_select }}))
 }

--- a/R/get_simd_datazone.R
+++ b/R/get_simd_datazone.R
@@ -4,6 +4,7 @@
 #' e.g. "2011"
 #' @param simd_version Default is "latest", otherwise supply a version
 #' e.g. "2020v2"
+#' @inheritParams readr::read_csv
 #'
 #' @return a [tibble][tibble::tibble-package] of the SIMD DataZone lookup
 #' @export
@@ -12,7 +13,8 @@
 #' get_simd_datazone()
 get_simd_datazone <- function(
     datazone_version = "latest",
-    simd_version = "latest") {
+    simd_version = "latest",
+    col_select = NULL) {
   dir <- fs::path(get_lookups_dir(), "Deprivation")
 
   if (datazone_version != "latest" && simd_version != "latest") {
@@ -36,5 +38,5 @@ get_simd_datazone <- function(
     )
   }
 
-  return(read_file(simd_datazone_path))
+  return(read_file(simd_datazone_path, col_select = {{ col_select }}))
 }

--- a/R/read_file.R
+++ b/R/read_file.R
@@ -17,9 +17,7 @@ read_file <- function(path, col_select = NULL, ...) {
     "csv",
     "parquet"
   )
-
   ext <- fs::path_ext(path)
-
 
   if (!(ext %in% valid_extensions)) {
     cli::cli_abort(c(
@@ -44,7 +42,9 @@ read_file <- function(path, col_select = NULL, ...) {
     ))
   )
 
-  if (!rlang::quo_is_null(rlang::enquo(col_select)) && ext == "rds") {
+  # If col_select was supplied keep only those variables
+  # This may sometimes be redundant, but it offers a final guarantee.
+  if (!rlang::quo_is_null(rlang::enquo(col_select))) {
     data <- dplyr::select(data, {{ col_select }})
   }
 

--- a/R/read_file.R
+++ b/R/read_file.R
@@ -45,7 +45,7 @@ read_file <- function(path, col_select = NULL, ...) {
   )
 
   if (!rlang::quo_is_null(rlang::enquo(col_select)) && ext == "rds") {
-    data <- dplyr::select(data, {{col_select}})
+    data <- dplyr::select(data, {{ col_select }})
   }
 
   return(data)

--- a/man/get_hscp_locality.Rd
+++ b/man/get_hscp_locality.Rd
@@ -4,10 +4,17 @@
 \alias{get_hscp_locality}
 \title{Get the HSCP Locality lookup}
 \usage{
-get_hscp_locality(version = "latest")
+get_hscp_locality(version = "latest", col_select = NULL)
 }
 \arguments{
 \item{version}{Default is "latest", otherwise supply a date e.g. "20230804"}
+
+\item{col_select}{Columns to include in the results. You can use the same
+mini-language as \code{dplyr::select()} to refer to the columns by name. Use
+\code{c()} to use more than one selection expression. Although this
+usage is less common, \code{col_select} also accepts a numeric column index. See
+\code{\link[tidyselect:language]{?tidyselect::language}} for full details on the
+selection language.}
 }
 \value{
 a \link[tibble:tibble-package]{tibble} of the HSCP localities lookup

--- a/man/get_simd_datazone.Rd
+++ b/man/get_simd_datazone.Rd
@@ -4,7 +4,11 @@
 \alias{get_simd_datazone}
 \title{Get a SIMD DataZone Lookup}
 \usage{
-get_simd_datazone(datazone_version = "latest", simd_version = "latest")
+get_simd_datazone(
+  datazone_version = "latest",
+  simd_version = "latest",
+  col_select = NULL
+)
 }
 \arguments{
 \item{datazone_version}{Default is "latest", otherwise supply a year
@@ -12,6 +16,13 @@ e.g. "2011"}
 
 \item{simd_version}{Default is "latest", otherwise supply a version
 e.g. "2020v2"}
+
+\item{col_select}{Columns to include in the results. You can use the same
+mini-language as \code{dplyr::select()} to refer to the columns by name. Use
+\code{c()} to use more than one selection expression. Although this
+usage is less common, \code{col_select} also accepts a numeric column index. See
+\code{\link[tidyselect:language]{?tidyselect::language}} for full details on the
+selection language.}
 }
 \value{
 a \link[tibble:tibble-package]{tibble} of the SIMD DataZone lookup

--- a/tests/testthat/test-get_hscp_locality.R
+++ b/tests/testthat/test-get_hscp_locality.R
@@ -16,3 +16,38 @@ test_that("hscp_locality lookup is returned", {
 
   expect_named(hscp_locality, hscp_locality_variables)
 })
+
+test_that("col selection works", {
+  expect_named(
+    get_hscp_locality(col_select = "datazone2011"),
+    "datazone2011"
+  ) |>
+    expect_message()
+  expect_named(
+    get_hscp_locality(col_select = c("datazone2011", "hscp_locality")),
+    c("datazone2011", "hscp_locality")
+  ) |>
+    expect_message()
+})
+
+test_that("col selection works with tidyselect", {
+  expect_named(
+    get_hscp_locality(col_select = dplyr::starts_with("hscp"))
+  ) |>
+    expect_message()
+
+  expect_named(
+    get_hscp_locality(col_select = c(dplyr::starts_with("hscp"), "datazone2011"))
+  ) |>
+    expect_message()
+
+  expect_named(
+    get_hscp_locality(col_select = c(dplyr::starts_with("hscp"), dplyr::starts_with("datazone")))
+  ) |>
+    expect_message()
+
+  expect_named(
+    get_hscp_locality(col_select = c("hscp_locality", dplyr::matches(".+?2019name$")))
+  ) |>
+    expect_message()
+})

--- a/tests/testthat/test-get_simd_datazone.R
+++ b/tests/testthat/test-get_simd_datazone.R
@@ -12,3 +12,38 @@ test_that("simd_datazone is returned", {
 
   expect_named(simd_datazone, simd_datazone_variables)
 })
+
+test_that("col selection works", {
+  expect_named(
+    get_simd_datazone(col_select = "datazone2011"),
+    "datazone2011"
+  ) |>
+    expect_message()
+  expect_named(
+    get_simd_datazone(col_select = c("datazone2011", "hscp2019", "simd2020v2_rank")),
+    c("datazone2011", "hscp2019", "simd2020v2_rank")
+  ) |>
+    expect_message()
+})
+
+test_that("col selection works with tidyselect", {
+  expect_named(
+    get_simd_datazone(col_select = dplyr::starts_with("simd"))
+  ) |>
+    expect_message()
+
+  expect_named(
+    get_simd_datazone(col_select = c(dplyr::starts_with("simd"), "datazone2011"))
+  ) |>
+    expect_message()
+
+  expect_named(
+    get_simd_datazone(col_select = c(dplyr::starts_with("simd"), dplyr::starts_with("datazone")))
+  ) |>
+    expect_message()
+
+  expect_named(
+    get_simd_datazone(col_select = dplyr::matches("^simd\\d{4}.+?decile$"))
+  ) |>
+    expect_message()
+})


### PR DESCRIPTION
* When using `parquet` it just uses the built-in - this is the most efficient
* When CSV is available it will use the `col_select` in `readr::read_csv` which results in less memory usage than reading the full file (but no speed improvement).
* When only RDS is available it reads that and then uses `dplyr::select` to filter the columns before returning the data to the user.

Note that if `col_select` isn't specified it will still read the RDS file (instead of CSV) as this is marginally more efficient.