### PR TITLE
Update to dev version 0.1.0.9000

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: phslookups
 Title: PHS Lookups
-Version: 0.1.0
+Version: 0.1.0.9000
 Authors@R: c(
     person("James", "Hayes", , "james.hayes2@phs.scot", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-5380-2029")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# phslookups (development version)
+
 # phslookups 0.1.0
 
 -   Initial version which includes: [`get_hscp_locality()`](https://public-health-scotland.github.io/phslookups/reference/get_hscp_locality.html), [`get_simd_datazone()`](https://public-health-scotland.github.io/phslookups/reference/get_simd_datazone.html), [`get_simd_postcode()`](https://public-health-scotland.github.io/phslookups/reference/get_simd_postcode.html), and [`get_spd()`](https://public-health-scotland.github.io/phslookups/reference/get_spd.html)


### PR DESCRIPTION
This is good practice now that it's on the Posit Package Manager, as we / others can tell if we've installed the fixed 0.1.0 that was git tagged / GitHub released and is served by the PHS PPM, or if we've installed from GitHub.