### PR TITLE
Refactor to make loading the metadata be on demand

### DIFF
--- a/R/get_spd.R
+++ b/R/get_spd.R
@@ -62,28 +62,18 @@ get_spd <- function(version = "latest", col_select = NULL) {
   )
 
   metadata_path <- fs::path(metadata_dir, "spd_metadata.csv")
+  metadata_exists <- fs::file_exists(metadata_path)
 
-  if (fs::file_exists(metadata_path)) {
-    metadata <- read_file(
-      metadata_path,
-      col_select = 1:2,
-      col_names = c("variable", "description"),
-      skip = 1,
-      col_types = readr::cols_only(
-        variable = readr::col_character(),
-        description = readr::col_character()
-      )
-    )
+  spd <- set_metadata_ref(
+    spd,
+    type = "SPD",
+    path = metadata_path,
+    version = version,
+    exists = metadata_exists
+  )
 
-    inform_metadata_access(metadata)
-
-    inform_metadata_version(version)
-
-    spd <- set_metadata(spd, metadata)
-  } else {
-    cli::cli_warn(
-      "SPD metadata file is not available and has not been attached"
-    )
+  if (metadata_exists) {
+    inform_metadata_access(spd)
   }
 
   return(spd)

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -22,13 +22,48 @@ metadata <- function(data) {
     )
   }
 
-  out <- attr(data, "metadata")
-
-  if (is.null(out)) {
-    cli::cli_abort("Metadata could not be found, please check")
+  # If already loaded, return immediately
+  metadata <- attr(data, "metadata", exact = TRUE)
+  if (!is.null(metadata)) {
+    return(metadata)
   }
 
-  out
+  ref <- attr(data, "metadata_ref", exact = TRUE)
+
+  if (rlang::is_false(ref$exists)) {
+    cli::cli_abort(c(
+      "x" = "{ref$type} metadata not available.",
+      "i" = "Expected at {.path {ref$path}}"
+    ))
+  }
+
+  metadata <- read_file(
+    ref$path,
+    col_select = 1:2,
+    col_names = c("variable", "description"),
+    skip = 1,
+    col_types = readr::cols_only(
+      variable = readr::col_character(),
+      description = readr::col_character()
+    )
+  )
+
+  inform_metadata_version(ref$version)
+
+  # Attach metadata to the object
+  set_metadata(data, metadata)
+
+  metadata
+}
+
+set_metadata_ref <- function(data, path, type, version, exists) {
+  attr(data, "metadata_ref") <- list(
+    path = path,
+    type = type,
+    version = version,
+    exists = exists
+  )
+  data
 }
 
 set_metadata <- function(data, metadata) {
@@ -37,15 +72,8 @@ set_metadata <- function(data, metadata) {
 }
 
 inform_metadata_access <- function(metadata) {
-  meta_print <- utils::capture.output(
-    print(metadata, n = 5)
-  )
-
   cli::cli_inform(c(
-    i = "Metadata has been attached and can be accessed using {.fun metadata}.",
-    cli::col_blue("------ Metadata -----"),
-    meta_print,
-    cli::col_blue("------")
+    i = "Metadata is available and can be accessed using {.fun metadata}."
   ))
 }
 

--- a/tests/testthat/test-get_spd.R
+++ b/tests/testthat/test-get_spd.R
@@ -3,7 +3,7 @@ skip_on_ci()
 test_that("spd is returned", {
   get_spd() |>
     expect_message("Using the latest available version") |>
-    expect_message("Metadata has been attached ")
+    expect_message("Metadata is available ")
 
   spd <- suppressMessages(get_spd())
 
@@ -21,13 +21,13 @@ test_that("col selection works", {
     "pc7"
   ) |>
     expect_message("Using the latest available version") |>
-    expect_message("Metadata has been attached ")
+    expect_message("Metadata is available ")
   expect_named(
     get_spd(col_select = c("pc7", "pc8")),
     c("pc7", "pc8")
   ) |>
     expect_message("Using the latest available version") |>
-    expect_message("Metadata has been attached ")
+    expect_message("Metadata is available ")
 })
 
 test_that("col selection works with tidyselect", {
@@ -35,22 +35,21 @@ test_that("col selection works with tidyselect", {
     get_spd(col_select = c("pc7", dplyr::starts_with("hb")))
   ) |>
     expect_message("Using the latest available version") |>
-    expect_message("Metadata has been attached ")
+    expect_message("Metadata is available ")
 
   expect_named(
     get_spd(col_select = dplyr::matches("pc[78]")),
     c("pc7", "pc8")
   ) |>
     expect_message("Using the latest available version") |>
-    expect_message("Metadata has been attached ")
+    expect_message("Metadata is available ")
 })
 
 
 test_that("reading from archive works", {
   get_spd(version = "2024_1") |>
     expect_s3_class("tbl_df") |>
-    expect_warning("Metadata is correct for the latest version ") |>
-    expect_message("Metadata has been attached ")
+    expect_message("Metadata is available ")
   expect_error(get_spd(version = "2010_1", "SPD version .+? is NOT available"))
   expect_error(get_spd(version = "20243"), "Invalid version name:")
 })


### PR DESCRIPTION
This offloads metadata loading to the first call of `metadata()`. When the lookup is loaded, it sets some attributes, such as where the metadata file is and whether it exists, but it's not loaded initially.

Overall, I think this is a better approach. The only downside is I couldn't figure out a good way to partially print the top few rows of the metadata, as that (obviously) involves reading it.