### PR TITLE
Release/v0.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: phslookups
 Title: PHS Lookups
-Version: 0.1.0.9000
+Version: 0.2.0
 Authors@R: c(
     person("James", "Hayes", , "james.hayes2@phs.scot", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-5380-2029")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# phslookups (development version)
+# phslookups 0.2.0
 
 -   Fixed a typo in the lookup path that meant the package wouldn't work on Windows (RStudio Desktop).
 -   Make the minimum required R version 4.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 
 -   Fixed a typo in the lookup path that meant the package wouldn't work on Windows (RStudio Desktop).
 -   Make the minimum required R version 4.1
+-   Metadata is now available! Currently, this is only for the Scottish Postcode Directory (`get_spd()`), but we will bring it to the other lookups soon, too. You can see the metadata by using `metadata()` on the lookup object, for example:
+```r
+spd <- get_spd()
+metadata(spd)
+```
 
 # phslookups 0.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # phslookups (development version)
 
+-   Fixed a typo in the lookup path that meant the package wouldn't work on Windows (RStudio Desktop).
+-   Make the minimum required R version 4.1
+
 # phslookups 0.1.0
 
--   Initial version which includes: [`get_hscp_locality()`](https://public-health-scotland.github.io/phslookups/reference/get_hscp_locality.html), [`get_simd_datazone()`](https://public-health-scotland.github.io/phslookups/reference/get_simd_datazone.html), [`get_simd_postcode()`](https://public-health-scotland.github.io/phslookups/reference/get_simd_postcode.html), and [`get_spd()`](https://public-health-scotland.github.io/phslookups/reference/get_spd.html)
+-   Initial version, which includes: [`get_hscp_locality()`](https://public-health-scotland.github.io/phslookups/reference/get_hscp_locality.html), [`get_simd_datazone()`](https://public-health-scotland.github.io/phslookups/reference/get_simd_datazone.html), [`get_simd_postcode()`](https://public-health-scotland.github.io/phslookups/reference/get_simd_postcode.html), and [`get_spd()`](https://public-health-scotland.github.io/phslookups/reference/get_spd.html)


### PR DESCRIPTION
Release candidate for version 0.2.0

The main change is that there was a typo in the file path for Windows, which was fixed in commit b637ffd, but meant that the package wouldn't have worked on Windows before then, and would have erronously given the error about 'insufficient access'.

There's also the change to the minimum required R version #40, and I'd like to include the README changes too #48.